### PR TITLE
fix(arcsync): 候选节点选择时校验 Pod 对节点污点的容忍

### DIFF
--- a/pkg/arcsync/arcsync.go
+++ b/pkg/arcsync/arcsync.go
@@ -15,8 +15,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
-	"k8s.io/client-go/tools/cache"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
@@ -125,11 +126,27 @@ func (pl *ARCSync) EventsToRegister(_ context.Context) ([]framework.ClusterEvent
 	}, nil
 }
 
-// canScheduleOnNode excludes only cordoned nodes (Unschedulable: true).
-// Tainted nodes are included — their NPU capacity is physically present and
-// counts toward global admission decisions.
-func canScheduleOnNode(node *v1.Node) bool {
-	return !node.Spec.Unschedulable
+// canScheduleOnNode excludes cordoned nodes (Unschedulable: true) and any node
+// carrying NoSchedule/NoExecute taints that the pod does not tolerate. Liqo
+// virtual nodes ship with their own taints, which Liqo tolerates on offloaded
+// pods, so those nodes remain eligible; a custom taint (e.g. 752t) that the pod
+// does not tolerate correctly removes the node from the candidate set.
+func canScheduleOnNode(pod *v1.Pod, node *v1.Node) bool {
+	if node.Spec.Unschedulable {
+		return false
+	}
+	return podToleratesNodeTaints(pod, node)
+}
+
+// podToleratesNodeTaints reports whether pod tolerates all NoSchedule/NoExecute
+// taints on node. PreferNoSchedule is intentionally ignored: it is a soft
+// preference, not a hard scheduling constraint (matching the built-in
+// TaintToleration filter).
+func podToleratesNodeTaints(pod *v1.Pod, node *v1.Node) bool {
+	_, isUntolerated := corev1helpers.FindMatchingUntoleratedTaint(node.Spec.Taints, pod.Spec.Tolerations, func(t *v1.Taint) bool {
+		return t.Effect == v1.TaintEffectNoSchedule || t.Effect == v1.TaintEffectNoExecute
+	})
+	return !isUntolerated
 }
 
 func nodeMatchesSelector(node *v1.Node, selector map[string]string) bool {
@@ -337,7 +354,7 @@ func (pl *ARCSync) PreFilter(ctx context.Context, state *framework.CycleState, p
 	nodeFreeNPU := make(map[string]int64)
 	for _, nodeInfo := range nodeInfos {
 		node := nodeInfo.Node()
-		if node == nil || !canScheduleOnNode(node) {
+		if node == nil || !canScheduleOnNode(pod, node) {
 			continue
 		}
 		if !nodeMatchesSelector(node, pod.Spec.NodeSelector) {
@@ -399,7 +416,7 @@ func (pl *ARCSync) PreFilter(ctx context.Context, state *framework.CycleState, p
 	var totalNPUFree int64
 	for _, nodeInfo := range nodeInfos {
 		node := nodeInfo.Node()
-		if node == nil || !canScheduleOnNode(node) {
+		if node == nil || !canScheduleOnNode(pod, node) {
 			continue
 		}
 		if isVirtualNode(node) {
@@ -492,7 +509,7 @@ func (pl *ARCSync) applyLiqoComparison(
 	var localTotalAllocatable, localTotalOccupied int64
 	for _, nodeInfo := range nodeInfos {
 		node := nodeInfo.Node()
-		if node == nil || isVirtualNode(node) || !canScheduleOnNode(node) {
+		if node == nil || isVirtualNode(node) || !canScheduleOnNode(pod, node) {
 			continue
 		}
 		if _, exists := nodeFreeNPU[node.Name]; !exists {


### PR DESCRIPTION
## 背景
cn12 集群通过 Liqo 将远端集群（aiframe、mind）接入为虚拟节点以实现统一资源池，cn12 的 runner 任务可被调度到远端集群。为避免带 800i 标签的任务被分配到 gy005 远端集群，在 gy005 虚拟节点上添加了名为 752t 的污点。

## 问题
调度器仍判定应将任务调度到 gy005 并完成绑定，但 gy005 带有 752t 污点而 Pod 没有对应容忍，导致任务一直卡住无法执行。

## 根因
pkg/arcsync/arcsync.go 中的 canScheduleOnNode 只排除了 cordon 节点，未对节点污点做任何判断，导致带 NoSchedule/NoExecute 污点的节点仍被纳入候选节点集合，最终被调度器选中。

## 修复
将 canScheduleOnNode 改为同时校验 Pod 容忍度：
- 仍排除 cordon 节点；
- 新增 podToleratesNodeTaints：仅当 Pod 容忍节点上所有 NoSchedule/NoExecute 污点时，该节点才可作为候选；
- PreferNoSchedule 为软性偏好，不参与硬性过滤，与内建 TaintToleration 语义一致。

效果：Liqo 虚拟节点自带污点（offload Pod 已由 Liqo 注入相应容忍）可继续通过；未容忍的自定义污点（如 752t）会被正确排除，不再调度到 gy005。

## 验证
- go build ./pkg/arcsync/... 通过
- go test ./pkg/arcsync/... 通过