### PR TITLE
fix(arcsync): only filter business NoSchedule taints

### DIFF
--- a/pkg/arcsync/arcsync.go
+++ b/pkg/arcsync/arcsync.go
@@ -3,6 +3,7 @@ package arcsync
 import (
 	"context"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -127,10 +128,11 @@ func (pl *ARCSync) EventsToRegister(_ context.Context) ([]framework.ClusterEvent
 }
 
 // canScheduleOnNode excludes cordoned nodes (Unschedulable: true) and any node
-// carrying NoSchedule/NoExecute taints that the pod does not tolerate. Liqo
-// virtual nodes ship with their own taints, which Liqo tolerates on offloaded
-// pods, so those nodes remain eligible; a custom taint (e.g. 752t) that the pod
-// does not tolerate correctly removes the node from the candidate set.
+// carrying a business NoSchedule taint that the pod does not tolerate (e.g.
+// dedicated=752t). Platform taints are intentionally ignored so ARCSync keeps
+// scheduling pods onto Liqo virtual nodes: NoExecute taints (runtime eviction)
+// and system taints under the reserved node.kubernetes.io/ and
+// virtual-node.liqo.io/ prefixes are managed by their own controllers.
 func canScheduleOnNode(pod *v1.Pod, node *v1.Node) bool {
 	if node.Spec.Unschedulable {
 		return false
@@ -138,13 +140,20 @@ func canScheduleOnNode(pod *v1.Pod, node *v1.Node) bool {
 	return podToleratesNodeTaints(pod, node)
 }
 
-// podToleratesNodeTaints reports whether pod tolerates all NoSchedule/NoExecute
-// taints on node. PreferNoSchedule is intentionally ignored: it is a soft
-// preference, not a hard scheduling constraint (matching the built-in
-// TaintToleration filter).
+// podToleratesNodeTaints reports whether pod tolerates every business
+// NoSchedule taint on node. It ignores NoExecute (a runtime eviction signal,
+// not a scheduling admission check), node.kubernetes.io/* condition taints
+// (e.g. route-unreachable) and virtual-node.liqo.io/* platform taints (e.g.
+// not-allowed), all of which are handled outside this scheduling path.
 func podToleratesNodeTaints(pod *v1.Pod, node *v1.Node) bool {
 	_, isUntolerated := corev1helpers.FindMatchingUntoleratedTaint(node.Spec.Taints, pod.Spec.Tolerations, func(t *v1.Taint) bool {
-		return t.Effect == v1.TaintEffectNoSchedule || t.Effect == v1.TaintEffectNoExecute
+		if t.Effect != v1.TaintEffectNoSchedule {
+			return false
+		}
+		if strings.HasPrefix(t.Key, "node.kubernetes.io/") || strings.HasPrefix(t.Key, "virtual-node.liqo.io/") {
+			return false
+		}
+		return true
 	})
 	return !isUntolerated
 }


### PR DESCRIPTION
## 背景
上一版修复（PR #10）在候选节点选择时对所有未容忍的 NoSchedule/NoExecute 污点做拦截，结果把 Liqo 虚拟节点自带的平台污点和系统条件污点也一并拦截，导致任务全部落在本地节点、无法调度到远端集群。

## 问题现象
虚拟节点实际带三类污点：
- irtual-node.liqo.io/not-allowed=true:NoExecute（Liqo 平台污点）
- 
ode.kubernetes.io/route-unreachable=null:NoSchedule（系统条件污点）
- dedicated=752t:NoSchedule（业务自定义污点）

上一版把前两类也当成“未容忍即排除”，导致 aiframe / mind / gy004 等正常虚拟节点全部不可调度。

## 修复
podToleratesNodeTaints 改为只对业务自定义的 NoSchedule 污点做准入判断：
- 忽略 NoExecute 污点（运行期驱逐语义，不参与调度过滤）；
- 忽略 
ode.kubernetes.io/* 前缀（系统条件污点，如 route-unreachable）；
- 忽略 irtual-node.liqo.io/* 前缀（Liqo 平台污点，如 not-allowed）。

效果：dedicated=752t:NoSchedule 仍会拦截未容忍 Pod（gy005 被排除），aiframe / mind / gy004 恢复正常调度，同时保留 PR #10 对业务污点的拦截能力。

## 验证
- go build ./pkg/arcsync/... 通过
- go test ./pkg/arcsync/... 通过