### PR TITLE
fix(arcsync): correct liqo local-vs-virtual comparison and honor pod …

### DIFF
--- a/pkg/arcsync/arcsync.go
+++ b/pkg/arcsync/arcsync.go
@@ -149,13 +149,24 @@ func podToleratesNodeTaints(pod *v1.Pod, node *v1.Node) bool {
 	return !isUntolerated
 }
 
-func nodeMatchesSelector(node *v1.Node, selector map[string]string) bool {
-	for k, v := range selector {
+// nodeMatchesPodSelection 判断节点是否同时满足 pod 的两类放置约束： 
+// spec.nodeSelector（label 精确相等）与
+// spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution
+// （terms 之间 OR，term 内条件 AND，复用 liqo.go 的 nodeSelectorTermsMatch）。
+func nodeMatchesPodSelection(node *v1.Node, pod *v1.Pod) bool {
+	for k, v := range pod.Spec.NodeSelector {
 		if node.Labels[k] != v {
 			return false
 		}
 	}
-	return true
+	if pod.Spec.Affinity == nil || pod.Spec.Affinity.NodeAffinity == nil {
+		return true
+	}
+	required := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	if required == nil {
+		return true
+	}
+	return nodeSelectorTermsMatch(labels.Set(node.Labels), required.NodeSelectorTerms)
 }
 
 func getBaseName(name string) string {
@@ -357,7 +368,7 @@ func (pl *ARCSync) PreFilter(ctx context.Context, state *framework.CycleState, p
 		if node == nil || !canScheduleOnNode(pod, node) {
 			continue
 		}
-		if !nodeMatchesSelector(node, pod.Spec.NodeSelector) {
+		if !nodeMatchesPodSelection(node, pod) {
 			continue
 		}
 		allocatable := node.Status.Allocatable[fullResourceName]

--- a/pkg/arcsync/arcsync_test.go
+++ b/pkg/arcsync/arcsync_test.go
@@ -323,6 +323,83 @@ func makeWorkloadPod(name, namespace, nodeName string, npuReq int64) *v1.Pod {
 	return pod
 }
 
+// withRequiredNodeAffinity 给 pod 设置 requiredDuringSchedulingIgnoredDuringExecution
+// 形式的 nodeAffinity。
+func withRequiredNodeAffinity(pod *v1.Pod, terms ...v1.NodeSelectorTerm) *v1.Pod {
+	pod.Spec.Affinity = &v1.Affinity{
+		NodeAffinity: &v1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{NodeSelectorTerms: terms},
+		},
+	}
+	return pod
+}
+
+func TestNodeMatchesPodSelection(t *testing.T) {
+	virtAIF := makeNodeWithNPU("virt-aif", 8, map[string]string{
+		"liqo.io/remote-cluster-id": "aiframework",
+		"liqo.io/type":              "virtual-node",
+	})
+	localNode := makeNodeWithNPU("local-1", 8, nil)
+
+	clusterInTerm := func(vals ...string) v1.NodeSelectorTerm {
+		return v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{{
+			Key: "liqo.io/remote-cluster-id", Operator: v1.NodeSelectorOpIn, Values: vals,
+		}}}
+	}
+	notVirtualTerm := v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{{
+		Key: "liqo.io/type", Operator: v1.NodeSelectorOpNotIn, Values: []string{"virtual-node"},
+	}}}
+
+	tests := []struct {
+		name string
+		node *v1.Node
+		pod  *v1.Pod
+		want bool
+	}{
+		{
+			name: "no affinity matches anything",
+			node: virtAIF,
+			pod:  makeRunnerPodWithLabels("p1", "ns1", 1),
+			want: true,
+		},
+		{
+			name: "affinity listing the cluster admits the virtual node",
+			node: virtAIF,
+			pod:  withRequiredNodeAffinity(makeRunnerPodWithLabels("p1", "ns1", 1), clusterInTerm("gy005", "aiframework"), notVirtualTerm),
+			want: true,
+		},
+		{
+			name: "affinity missing the cluster excludes the virtual node",
+			node: virtAIF,
+			pod:  withRequiredNodeAffinity(makeRunnerPodWithLabels("p1", "ns1", 1), clusterInTerm("gy005", "mind-third-ci"), notVirtualTerm),
+			want: false,
+		},
+		{
+			name: "not-in virtual-node term admits local node (label missing)",
+			node: localNode,
+			pod:  withRequiredNodeAffinity(makeRunnerPodWithLabels("p1", "ns1", 1), clusterInTerm("gy005", "mind-third-ci"), notVirtualTerm),
+			want: true,
+		},
+		{
+			name: "nodeSelector still enforced",
+			node: virtAIF,
+			pod: func() *v1.Pod {
+				pod := makeRunnerPodWithLabels("p1", "ns1", 1)
+				pod.Spec.NodeSelector = map[string]string{"liqo.io/remote-cluster-id": "gy005"}
+				return pod
+			}(),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := nodeMatchesPodSelection(tt.node, tt.pod); got != tt.want {
+				t.Errorf("nodeMatchesPodSelection() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 type fakeSharedLister struct {
 	nodeInfos []*framework.NodeInfo
 	nodeMap   map[string]*framework.NodeInfo
@@ -540,6 +617,82 @@ func TestPreFilterVirtualWinsWhenLocalOccupiedByOtherNamespace(t *testing.T) {
 	}
 	if _, exists := preState.nodeFreeNPU["local-1"]; exists {
 		t.Errorf("expected local-1 to be excluded (fully occupied by other namespace)")
+	}
+}
+
+func TestPreFilterAffinityExcludesNonTargetedVirtual(t *testing.T) {
+	// 复现线上问题：pod 通过 nodeAffinity 只允许 gy005/mind-third-ci（及本地），
+	// 而 NamespaceOffloading clusterSelector 新增了剩余更多的 aiframework。
+	// 修复前 ARCSync 会选 aiframework 为 bestVirtNode 并删掉 mind-third-ci，
+	// 随后被默认 NodeAffinity 插件拒绝，pod 无处可调；修复后 aiframework 在
+	// PreFilter 就被排除，virtual-wins 只保留允许的 mind-third-ci。
+	localNode := makeNodeWithNPU("local-1", 2, nil)
+	virtGy005 := makeNodeWithNPU("virt-gy005", 8, map[string]string{
+		"liqo.io/remote-cluster-id": "gy005", "liqo.io/type": "virtual-node"})
+	virtMind := makeNodeWithNPU("virt-mind", 10, map[string]string{
+		"liqo.io/remote-cluster-id": "mind-third-ci", "liqo.io/type": "virtual-node"})
+	virtAIF := makeNodeWithNPU("virt-aif", 20, map[string]string{
+		"liqo.io/remote-cluster-id": "aiframework", "liqo.io/type": "virtual-node"})
+
+	pod := makeRunnerPodWithLabels("new-runner", "ns1", 1)
+	withRequiredNodeAffinity(pod,
+		v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{{
+			Key: "liqo.io/remote-cluster-id", Operator: v1.NodeSelectorOpIn,
+			Values: []string{"gy005", "mind-third-ci"},
+		}}},
+		v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{{
+			Key: "liqo.io/type", Operator: v1.NodeSelectorOpNotIn,
+			Values: []string{"virtual-node"},
+		}}},
+	)
+
+	allPods := []*v1.Pod{pod}
+	nodes := []*v1.Node{localNode, virtGy005, virtMind, virtAIF}
+
+	fwk, state := setupTestFramework(t, allPods, nodes)
+
+	// clusterSelector 覆盖全部三个 cluster（含新增的 aiframework）
+	nsOffloading := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	selectorMap := map[string]interface{}{
+		"nodeSelectorTerms": []interface{}{
+			map[string]interface{}{
+				"matchExpressions": []interface{}{
+					map[string]interface{}{
+						"key":      "liqo.io/remote-cluster-id",
+						"operator": "In",
+						"values":   []interface{}{"gy005", "mind-third-ci", "aiframework"},
+					},
+				},
+			},
+		},
+	}
+	unstructured.SetNestedMap(nsOffloading.Object, selectorMap, "spec", "clusterSelector")
+
+	pl := &ARCSync{
+		handle:               fwk,
+		inFlightReservations: make(map[string]reservation),
+		nsOffloadingLister:   &fakeNSOffloadingLister{objects: map[string]*unstructured.Unstructured{"ns1": nsOffloading}},
+		queueLister:          &fakeQueueLister{objects: map[string]*unstructured.Unstructured{}},
+	}
+
+	_, status := pl.PreFilter(context.TODO(), state, pod)
+	if status.Code() != framework.Success {
+		t.Fatalf("PreFilter failed: %v", status.Message())
+	}
+
+	data, err := state.Read(stateKey)
+	if err != nil {
+		t.Fatalf("failed to read state: %v", err)
+	}
+	preState := data.(*preFilterState)
+	if _, exists := preState.nodeFreeNPU["virt-aif"]; exists {
+		t.Errorf("virt-aif must NOT be in nodeFreeNPU (excluded by pod nodeAffinity)")
+	}
+	if _, exists := preState.nodeFreeNPU["virt-mind"]; !exists {
+		t.Errorf("expected virt-mind in nodeFreeNPU (virtual wins: 10 > local 2, 10 > gy005 8)")
+	}
+	if _, exists := preState.nodeFreeNPU["virt-gy005"]; exists {
+		t.Errorf("virt-gy005 should be excluded by virtual-wins (only bestVirtNode virt-mind kept)")
 	}
 }
 


### PR DESCRIPTION
…nodeAffinity

- localRemaining 改用本地节点全量占用口径（nodeFreeNPU 之和）： 此前用 nsLocalOccupied（仅当前 namespace 占用）做减数，本地被其他 namespace 占满时会高估本地剩余、误判 local wins 并删除虚拟节点， 导致 pod 无处可调；queue 配额改为与物理剩余取 min
- nodeMatchesPodSelection 在 nodeSelector 之外同时校验 requiredDuringSchedulingIgnoredDuringExecution 的 nodeAffinity： 此前 affinity 钉死部分 cluster 的 pod 会把 affinity 不允许、剩余最多 的虚拟节点选成 bestVirtNode 并删掉真正可去的节点，最终被默认 NodeAffinity 插件拒绝，两头落空
- 新增测试：本地被其他 namespace 占满、affinity 排除虚拟节点、 nodeMatchesPodSelection 单元用例

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```
